### PR TITLE
Add Function Expression Methods, Auto-quoted Aliases, and String Operators

### DIFF
--- a/pkg/cypher/cypher.go
+++ b/pkg/cypher/cypher.go
@@ -504,6 +504,72 @@ func Max(expression core.Expression) core.Expression {
 	return expr.Max(expression)
 }
 
+// Collect creates a COLLECT function expression
+func Collect(expression core.Expression) core.Expression {
+	return expr.Collect(expression)
+}
+
+// Distinct wraps an expression with DISTINCT keyword
+func Distinct(expression core.Expression) core.Expression {
+	return expr.Distinct(expression)
+}
+
+// String operators
+// ================================================================
+
+// Concat concatenates multiple string expressions using the + operator
+func Concat(expressions ...core.Expression) core.Expression {
+	return expr.Concat(expressions...)
+}
+
+// Substring creates a SUBSTRING function expression
+// substring(expression, start [, length])
+func Substring(expression core.Expression, start core.Expression, length ...core.Expression) core.Expression {
+	return expr.Substring(expression, start, length...)
+}
+
+// Replace creates a REPLACE function expression
+func Replace(expression, search, replace core.Expression) core.Expression {
+	return expr.Replace(expression, search, replace)
+}
+
+// Split creates a SPLIT function expression
+func Split(expression, delimiter core.Expression) core.Expression {
+	return expr.Split(expression, delimiter)
+}
+
+// ToLower creates a toLower function expression
+func ToLower(expression core.Expression) core.Expression {
+	return expr.ToLower(expression)
+}
+
+// ToUpper creates a toUpper function expression
+func ToUpper(expression core.Expression) core.Expression {
+	return expr.ToUpper(expression)
+}
+
+// Trim creates a TRIM function expression
+func Trim(expression core.Expression) core.Expression {
+	return expr.Trim(expression)
+}
+
+// LTrim creates a lTrim function expression
+func LTrim(expression core.Expression) core.Expression {
+	return expr.LTrim(expression)
+}
+
+// RTrim creates a rTrim function expression
+func RTrim(expression core.Expression) core.Expression {
+	return expr.RTrim(expression)
+}
+
+// RawCypher creates a raw Cypher expression that will be inserted as-is into the query
+// WARNING: Use with caution to avoid Cypher injection vulnerabilities.
+// Only use this when the DSL doesn't support a specific Cypher feature.
+func RawCypher(cypher string) core.Expression {
+	return expr.RawCypher(cypher)
+}
+
 // Utility functions
 
 // convertProperties converts a map of Go values to a map of Expression values

--- a/pkg/cypher/expr/alias.go
+++ b/pkg/cypher/expr/alias.go
@@ -2,6 +2,8 @@ package expr
 
 import (
 	"fmt"
+	"strings"
+	"unicode"
 
 	"github.com/nivohavi/go-cypher-dsl/pkg/cypher/core"
 )
@@ -17,9 +19,41 @@ func (a *AliasExpression) Accept(visitor core.ExpressionVisitor) any {
 	return visitor.Visit(a)
 }
 
+// quoteIdentifier quotes an identifier with backticks if it contains special characters
+// or if it's already quoted, returns it as-is
+func quoteIdentifier(identifier string) string {
+	// If already quoted, return as-is
+	if len(identifier) >= 2 && identifier[0] == '`' && identifier[len(identifier)-1] == '`' {
+		return identifier
+	}
+
+	// Check if identifier needs quoting (contains spaces, dots, or other special characters)
+	needsQuoting := false
+	for _, r := range identifier {
+		if !unicode.IsLetter(r) && !unicode.IsDigit(r) && r != '_' {
+			needsQuoting = true
+			break
+		}
+	}
+
+	// Also quote if it starts with a digit
+	if len(identifier) > 0 && unicode.IsDigit(rune(identifier[0])) {
+		needsQuoting = true
+	}
+
+	if needsQuoting {
+		// Escape backticks inside the identifier
+		escaped := strings.ReplaceAll(identifier, "`", "``")
+		return fmt.Sprintf("`%s`", escaped)
+	}
+
+	return identifier
+}
+
 // String returns a string representation of this alias expression
 func (a *AliasExpression) String() string {
-	return fmt.Sprintf("%s AS %s", a.Expression.String(), a.Alias)
+	quotedAlias := quoteIdentifier(a.Alias)
+	return fmt.Sprintf("%s AS %s", a.Expression.String(), quotedAlias)
 }
 
 // And creates a logical AND with another expression

--- a/pkg/cypher/expr/function.go
+++ b/pkg/cypher/expr/function.go
@@ -1,6 +1,7 @@
 package expr
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/nivohavi/go-cypher-dsl/pkg/cypher/core"
@@ -47,6 +48,64 @@ func (f *FunctionExpression) Not() core.Expression {
 	return Not(f)
 }
 
+// As creates an alias for this function expression
+func (f *FunctionExpression) As(alias string) core.Expression {
+	return As(f, alias)
+}
+
+// DistinctExpression represents an expression wrapped with DISTINCT (e.g., DISTINCT n)
+type DistinctExpression struct {
+	Expression core.Expression
+}
+
+// Accept implements the Expression interface
+func (d *DistinctExpression) Accept(visitor core.ExpressionVisitor) any {
+	return visitor.Visit(d)
+}
+
+// String returns a string representation of this distinct expression
+func (d *DistinctExpression) String() string {
+	return "DISTINCT " + d.Expression.String()
+}
+
+// And creates a logical AND with another expression
+func (d *DistinctExpression) And(other core.Expression) core.Expression {
+	return And(d, other)
+}
+
+// Or creates a logical OR with another expression
+func (d *DistinctExpression) Or(other core.Expression) core.Expression {
+	return Or(d, other)
+}
+
+// Not creates a logical NOT of this expression
+func (d *DistinctExpression) Not() core.Expression {
+	return Not(d)
+}
+
+// Distinct wraps an expression with DISTINCT keyword
+func Distinct(expr core.Expression) core.Expression {
+	return &DistinctExpression{Expression: expr}
+}
+
+// Distinct wraps this function expression's first argument with DISTINCT
+// This is useful for count(DISTINCT expr) patterns
+func (f *FunctionExpression) Distinct() core.Expression {
+	if len(f.Arguments) == 0 {
+		return f
+	}
+	// Create a new function with the first argument wrapped in DISTINCT
+	args := make([]core.Expression, len(f.Arguments))
+	args[0] = Distinct(f.Arguments[0])
+	for i := 1; i < len(f.Arguments); i++ {
+		args[i] = f.Arguments[i]
+	}
+	return &FunctionExpression{
+		Name:      f.Name,
+		Arguments: args,
+	}
+}
+
 // Function creates a new function expression
 func Function(name string, args ...core.Expression) core.Expression {
 	return &FunctionExpression{
@@ -86,4 +145,151 @@ func Min(expr core.Expression) core.Expression {
 // Max creates a MAX function expression
 func Max(expr core.Expression) core.Expression {
 	return Function("max", expr)
+}
+
+// Collect creates a COLLECT function expression
+func Collect(expr core.Expression) core.Expression {
+	return Function("collect", expr)
+}
+
+// BinaryExpression represents a binary operation (e.g., a + b)
+type BinaryExpression struct {
+	Left     core.Expression
+	Right    core.Expression
+	Operator string
+}
+
+// Accept implements the Expression interface
+func (b *BinaryExpression) Accept(visitor core.ExpressionVisitor) any {
+	return visitor.Visit(b)
+}
+
+// String returns a string representation of this binary expression
+func (b *BinaryExpression) String() string {
+	return fmt.Sprintf("(%s %s %s)", b.Left.String(), b.Operator, b.Right.String())
+}
+
+// And creates a logical AND with another expression
+func (b *BinaryExpression) And(other core.Expression) core.Expression {
+	return And(b, other)
+}
+
+// Or creates a logical OR with another expression
+func (b *BinaryExpression) Or(other core.Expression) core.Expression {
+	return Or(b, other)
+}
+
+// Not creates a logical NOT of this expression
+func (b *BinaryExpression) Not() core.Expression {
+	return Not(b)
+}
+
+// Concat concatenates multiple string expressions using the + operator
+// This chains expressions: expr1 + expr2 + expr3 + ...
+func Concat(expressions ...core.Expression) core.Expression {
+	if len(expressions) == 0 {
+		return String("")
+	}
+	if len(expressions) == 1 {
+		return expressions[0]
+	}
+	// Chain expressions with + operator
+	result := &BinaryExpression{
+		Left:     expressions[0],
+		Right:    expressions[1],
+		Operator: "+",
+	}
+	for i := 2; i < len(expressions); i++ {
+		result = &BinaryExpression{
+			Left:     result,
+			Right:    expressions[i],
+			Operator: "+",
+		}
+	}
+	return result
+}
+
+// Substring creates a SUBSTRING function expression
+// substring(expr, start [, length])
+func Substring(expr core.Expression, start core.Expression, length ...core.Expression) core.Expression {
+	args := []core.Expression{expr, start}
+	if len(length) > 0 {
+		args = append(args, length[0])
+	}
+	return Function("substring", args...)
+}
+
+// Replace creates a REPLACE function expression
+// replace(expr, search, replace)
+func Replace(expr, search, replace core.Expression) core.Expression {
+	return Function("replace", expr, search, replace)
+}
+
+// Split creates a SPLIT function expression
+// split(expr, delimiter)
+func Split(expr, delimiter core.Expression) core.Expression {
+	return Function("split", expr, delimiter)
+}
+
+// ToLower creates a toLower function expression
+func ToLower(expr core.Expression) core.Expression {
+	return Function("toLower", expr)
+}
+
+// ToUpper creates a toUpper function expression
+func ToUpper(expr core.Expression) core.Expression {
+	return Function("toUpper", expr)
+}
+
+// Trim creates a TRIM function expression
+func Trim(expr core.Expression) core.Expression {
+	return Function("trim", expr)
+}
+
+// LTrim creates a lTrim function expression
+func LTrim(expr core.Expression) core.Expression {
+	return Function("lTrim", expr)
+}
+
+// RTrim creates a rTrim function expression
+func RTrim(expr core.Expression) core.Expression {
+	return Function("rTrim", expr)
+}
+
+// RawCypherExpression represents a raw Cypher string that will be inserted as-is
+// WARNING: Use with caution to avoid Cypher injection vulnerabilities
+type RawCypherExpression struct {
+	Cypher string
+}
+
+// Accept implements the Expression interface
+func (r *RawCypherExpression) Accept(visitor core.ExpressionVisitor) any {
+	return visitor.Visit(r)
+}
+
+// String returns the raw Cypher string
+func (r *RawCypherExpression) String() string {
+	return r.Cypher
+}
+
+// And creates a logical AND with another expression
+func (r *RawCypherExpression) And(other core.Expression) core.Expression {
+	return And(r, other)
+}
+
+// Or creates a logical OR with another expression
+func (r *RawCypherExpression) Or(other core.Expression) core.Expression {
+	return Or(r, other)
+}
+
+// Not creates a logical NOT of this expression
+func (r *RawCypherExpression) Not() core.Expression {
+	return Not(r)
+}
+
+// RawCypher creates a raw Cypher expression that will be inserted as-is into the query
+// WARNING: Use with caution to avoid Cypher injection vulnerabilities.
+// Only use this when the DSL doesn't support a specific Cypher feature.
+func RawCypher(cypher string) core.Expression {
+	return &RawCypherExpression{Cypher: cypher}
 }


### PR DESCRIPTION
## Summary

This PR addresses three GitHub issues by adding missing functionality to the Cypher DSL:

1. **Function Expression Methods**: Adds `As()` and `Distinct()` methods to `FunctionExpression`, implements `Collect()` function, and adds `Distinct()` helper
2. **Auto-quoted Aliases**: Automatically quotes aliases containing special characters in `As()` method
3. **String Operators & Raw Cypher**: Adds comprehensive string operator functions and `RawCypher()` escape hatch

## Changes

### 1. Function Expression Methods (#issue-1)

- ✅ Added `As(alias string)` method to `FunctionExpression` for fluent chaining: `count(expr).As("myvar")`
- ✅ Added `Distinct()` method to `FunctionExpression` for `count(DISTINCT expr)` patterns
- ✅ Added `Distinct(expr)` helper function to wrap any expression with DISTINCT keyword
- ✅ Implemented `Collect(expr)` function for aggregation operations

**Example usage:**
```go
// Count with alias
cypher.Count(person).As("count")

// Count distinct
cypher.Count(cypher.Distinct(person.Property("name"))).As("uniqueNames")

// Collect aggregation
cypher.Collect(person.Property("name")).As("names")
```

### 2. Auto-quoted Aliases (#issue-2)

- ✅ Implemented `quoteIdentifier()` utility function that detects when backticks are needed
- ✅ Updated `AliasExpression.String()` to automatically quote aliases containing special characters
- ✅ Handles edge cases: already-quoted aliases, escaping backticks inside identifiers, identifiers starting with digits

**Example usage:**
```go
// Automatically quotes aliases with dots, spaces, or special characters
cypher.As(n.Property("Field"), "Member.Field")  // Renders as: n.Field AS `Member.Field`
cypher.As(n.Property("name"), "person_name")    // Renders as: n.name AS person_name (no quotes needed)
```

### 3. String Operators & Raw Cypher Escape Hatch (#issue-3)

- ✅ Added string operator functions:
  - `Concat(...expressions)` - concatenates strings using `+` operator
  - `Substring(expr, start [, length])` - substring function
  - `Replace(expr, search, replace)` - replace function
  - `Split(expr, delimiter)` - split function
  - `ToLower(expr)`, `ToUpper(expr)` - case conversion
  - `Trim(expr)`, `LTrim(expr)`, `RTrim(expr)` - trimming functions
- ✅ Created `RawCypher(cypher string)` escape hatch for inserting literal Cypher strings (with security warning)

**Example usage:**
```go
// String concatenation
cypher.Concat(
    person.Property("firstName"),
    cypher.String(" "),
    person.Property("lastName"),
).As("fullName")

// String operations
cypher.ToLower(person.Property("email"))
cypher.Substring(person.Property("name"), cypher.Integer(0), cypher.Integer(10))
cypher.Replace(person.Property("name"), cypher.String(" "), cypher.String("_"))

// Raw Cypher escape hatch
cypher.RawCypher("n.name + ' ' + n.surname").As("fullName")
```

## Files Modified

- `pkg/cypher/expr/function.go` - Added function methods, distinct support, string operators, and raw Cypher
- `pkg/cypher/expr/alias.go` - Added auto-quoting logic
- `pkg/cypher/cypher.go` - Exported all new functions in public API

## Breaking Changes

None - all changes are additive and backward compatible.

